### PR TITLE
Update simple mode logic based on login role

### DIFF
--- a/web/src/hooks/chat-hooks.ts
+++ b/web/src/hooks/chat-hooks.ts
@@ -111,11 +111,7 @@ export const useFetchNextDialogList = (pureFetch = false) => {
               handleClickDialog(data.data[0].id);
             }
           } else {
-              history.push(
-                currentQueryParameters.get('simple') === '1'
-                ? '/chat?simple=1'
-                : '/chat',
-            );
+              history.push('/chat');
           }
         }
       }

--- a/web/src/hooks/login-hooks.ts
+++ b/web/src/hooks/login-hooks.ts
@@ -69,6 +69,7 @@ export const useLogin = () => {
           avatar: data.avatar,
           name: data.nickname,
           email: data.email,
+          role: data.role,
         };
         authorizationUtil.setItems({
           Authorization: authorization,

--- a/web/src/hooks/use-chat-request.ts
+++ b/web/src/hooks/use-chat-request.ts
@@ -66,11 +66,7 @@ export const useFetchDialogList = (pureFetch = false) => {
               handleClickDialog(data.data[0].id);
             }
           } else {
-              history.push(
-                currentQueryParameters.get('simple') === '1'
-                ? '/chat?simple=1'
-                : '/chat',
-            );
+              history.push('/chat');
           }
         }
       }

--- a/web/src/interfaces/database/user-setting.ts
+++ b/web/src/interfaces/database/user-setting.ts
@@ -14,6 +14,7 @@ export interface IUserInfo {
   last_login_time: string;
   login_channel: string;
   nickname: string;
+  role: string;
   password: string;
   status: string;
   update_date: string;

--- a/web/src/layouts/chat-only-header.tsx
+++ b/web/src/layouts/chat-only-header.tsx
@@ -19,7 +19,6 @@ import { useFetchAppConf } from '@/hooks/logic-hooks';
 import { useNavigateWithFromState } from '@/hooks/route-hook';
 import { useFetchUserInfo, useListTenant } from '@/hooks/user-setting-hooks';
 import authorizationUtil from '@/utils/authorization-util';
-import { useSearchParams } from 'umi';
 import { TenantRole } from '@/pages/user-setting/constants';
 import { Routes } from '@/routes';
 import { camelCase } from 'lodash';
@@ -37,11 +36,9 @@ export function ChatOnlyHeader() {
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const navigate = useNavigateWithFromState();
-  const [searchParams] = useSearchParams();
   const handleProfileClick = useCallback(() => {
-    const simple = searchParams.get('simple') === '1' ? '?simple=1' : '';
-    navigate(`/user-setting${simple}`);
-  }, [navigate, searchParams]);
+    navigate('/user-setting');
+  }, [navigate]);
 
   const changeLanguage = useChangeLanguage();
   const { setTheme, theme } = useTheme();
@@ -89,7 +86,7 @@ export function ChatOnlyHeader() {
     (path: string): MouseEventHandler =>
       (e) => {
         e.preventDefault();
-        navigate(`${path}?simple=1` as Routes);
+        navigate(path as Routes);
       },
     [navigate],
   );
@@ -122,7 +119,7 @@ export function ChatOnlyHeader() {
             value={item.name}
             key={item.name}
           >
-            <a href={`${item.path}?simple=1`}>
+            <a href={item.path}>
               <Flex
                 align="center"
                 gap={8}

--- a/web/src/layouts/components/user/index.tsx
+++ b/web/src/layouts/components/user/index.tsx
@@ -1,7 +1,7 @@
 import { useFetchUserInfo } from '@/hooks/user-setting-hooks';
 import { Avatar } from 'antd';
 import React from 'react';
-import { useNavigate, useSearchParams } from 'umi';
+import { useNavigate } from 'umi';
 
 import styles from '../../index.less';
 
@@ -9,10 +9,8 @@ const App: React.FC = () => {
   const { data: userInfo } = useFetchUserInfo();
 
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const toSetting = () => {
-    const simple = searchParams.get('simple') === '1' ? '?simple=1' : '';
-    navigate(`/user-setting${simple}`);
+    navigate('/user-setting');
   };
 
   return (

--- a/web/src/layouts/index.tsx
+++ b/web/src/layouts/index.tsx
@@ -1,6 +1,7 @@
 import { Divider, Layout, theme } from 'antd';
 import React from 'react';
-import { Outlet, useLocation } from 'umi';
+import { Outlet } from 'umi';
+import authorizationUtil from '@/utils/authorization-util';
 import '../locales/config';
 import Header from './components/header';
 import { ChatOnlyHeader } from './chat-only-header';
@@ -14,9 +15,7 @@ const App: React.FC = () => {
     token: { colorBgContainer, borderRadiusLG },
   } = theme.useToken();
 
-  const location = useLocation();
-  const search = new URLSearchParams(location.search);
-  const simpleMode = search.get('simple') === '1';
+  const simpleMode = authorizationUtil.isQueryRole();
   return (
     <Layout className={styles.layout}>
       <Layout>

--- a/web/src/layouts/next.tsx
+++ b/web/src/layouts/next.tsx
@@ -1,11 +1,11 @@
-import { Outlet, useSearchParams } from 'umi';
+import { Outlet } from 'umi';
 import { Header } from './next-header';
 import { ChatOnlyHeader } from './chat-only-header';
+import authorizationUtil from '@/utils/authorization-util';
 
 
 export default function NextLayout() {
-  const [searchParams] = useSearchParams();
-  const simpleMode = searchParams.get('simple') === '1';
+  const simpleMode = authorizationUtil.isQueryRole();
 
   return (
     <section className="h-full flex flex-col text-colors-text-neutral-strong">

--- a/web/src/pages/chat/index.tsx
+++ b/web/src/pages/chat/index.tsx
@@ -45,14 +45,13 @@ import { useSetSelectedRecord } from '@/hooks/logic-hooks';
 import { IDialog } from '@/interfaces/database/chat';
 import { PictureInPicture2 } from 'lucide-react';
 import styles from './index.less';
-import { useSearchParams } from 'umi';
+import authorizationUtil from '@/utils/authorization-util';
 
 const { Text } = Typography;
 
 const Chat = () => {
   const { data: dialogList, loading: dialogLoading } = useFetchNextDialogList();
-  const [searchParams] = useSearchParams();
-  const simpleMode = searchParams.get('simple') === '1';
+  const simpleMode = authorizationUtil.isQueryRole();
   const { onRemoveDialog } = useDeleteDialog();
   const { onRemoveConversation } = useDeleteConversation();
   const { handleClickDialog } = useClickDialogCard();

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -1,5 +1,6 @@
 import SvgIcon from '@/components/svg-icon';
 import { useAuth } from '@/hooks/auth-hooks';
+import authorizationUtil from '@/utils/authorization-util';
 import {
   useLogin,
   useLoginChannels,
@@ -36,7 +37,8 @@ const Login = () => {
   const { isLogin } = useAuth();
   useEffect(() => {
     if (isLogin) {
-      navigate('/knowledge');
+      const role = authorizationUtil.getUserRole();
+      navigate(role === 'query' ? '/chat' : '/knowledge');
     }
   }, [isLogin, navigate]);
 
@@ -68,7 +70,8 @@ const Login = () => {
           password: rsaPassWord,
         });
         if (code === 0) {
-          navigate('/knowledge');
+          const role = authorizationUtil.getUserRole();
+          navigate(role === 'query' ? '/chat' : '/knowledge');
         }
       } else {
         const code = await register({

--- a/web/src/pages/simple/index.tsx
+++ b/web/src/pages/simple/index.tsx
@@ -3,7 +3,7 @@ import { history } from 'umi';
 
 export default function SimpleHome() {
   useEffect(() => {
-    history.replace('/chat?simple=1');
+    history.replace('/chat');
   }, []);
   return null;
 }

--- a/web/src/pages/user-setting/sidebar/index.tsx
+++ b/web/src/pages/user-setting/sidebar/index.tsx
@@ -6,7 +6,8 @@ import { useFetchSystemVersion } from '@/hooks/user-setting-hooks';
 import type { MenuProps } from 'antd';
 import { Flex, Menu } from 'antd';
 import React, { useEffect, useMemo } from 'react';
-import { useNavigate, useSearchParams } from 'umi';
+import { useNavigate } from 'umi';
+import authorizationUtil from '@/utils/authorization-util';
 import {
   UserSettingBaseKey,
   UserSettingIconMap,
@@ -19,11 +20,10 @@ type MenuItem = Required<MenuProps>['items'][number];
 const SideBar = () => {
   const navigate = useNavigate();
   const pathName = useSecondPathName();
-  const [searchParams] = useSearchParams();
   const { logout } = useLogout();
   const { t } = useTranslate('setting');
   const { version, fetchSystemVersion } = useFetchSystemVersion();
-  const simple = searchParams.get('simple') === '1';
+  const simple = authorizationUtil.isQueryRole();
 
   useEffect(() => {
     if (location.host !== Domain) {
@@ -69,8 +69,7 @@ const items: MenuItem[] = useMemo(() => {
     if (key === UserSettingRouteKey.Logout) {
       logout();
     } else {
-      const simpleParam = simple ? '?simple=1' : '';
-      navigate(`/${UserSettingBaseKey}/${key}${simpleParam}`);
+      navigate(`/${UserSettingBaseKey}/${key}`);
     }
   };
 

--- a/web/src/utils/authorization-util.ts
+++ b/web/src/utils/authorization-util.ts
@@ -13,7 +13,21 @@ const storage = {
     return localStorage.getItem(UserInfo);
   },
   getUserInfoObject: () => {
-    return JSON.parse(localStorage.getItem('userInfo') || '');
+    try {
+      return JSON.parse(localStorage.getItem('userInfo') || '{}');
+    } catch (e) {
+      return {};
+    }
+  },
+  getUserRole: (): string | undefined => {
+    try {
+      return JSON.parse(localStorage.getItem('userInfo') || '{}').role;
+    } catch (e) {
+      return undefined;
+    }
+  },
+  isQueryRole: () => {
+    return storage.getUserRole() === 'query';
   },
   setAuthorization: (value: string) => {
     localStorage.setItem(Authorization, value);


### PR DESCRIPTION
## Summary
- extend `authorizationUtil` to expose `getUserRole` and `isQueryRole`
- store user role on login
- navigate according to role in login page
- detect simplified mode from stored role instead of URL
- remove `simple` query handling and redirects

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb83441a083329e5eef3f5cc5b662