### PR TITLE
Add storage type logging and configuration fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Python Backend Overview
+
+## 1. Framework and Dependencies
+- The backend uses **Flask** for the HTTP API. Initialization occurs in `api/apps/__init__.py` where `Flask` and `LoginManager` are set up.
+- Database access relies on **Peewee** with `PooledMySQLDatabase` for connection pooling.
+- Asynchronous background tasks in `rag/svr/task_executor.py` use **Trio**.
+- Object storage is handled by **MinIO** via the `minio` Python client.
+
+Python dependencies are installed via `uv` as documented in `docs/develop/launch_ragflow_from_source.md` using a Python 3.10 virtual environment.
+
+## 2. Project Structure
+- `api/` – Flask application and REST endpoints.
+- `rag/` – document processing logic and background task executor.
+- `plugin/` – plugin framework loaded on startup.
+- `conf/service_conf.yaml` – runtime configuration for services like MySQL, MinIO and Redis.
+- Entry points:
+  - `python api/ragflow_server.py`
+  - `python rag/svr/task_executor.py`
+  Both require `PYTHONPATH=.`, as shown in development docs.
+
+## 3. Login and Permission Filtering
+- `LoginManager` loads users from the `Authorization` header via JWT tokens. See `load_user` in `api/apps/__init__.py`.
+- API routes use `@login_required` for session based checks or `token_required` for API key validation.
+- `token_required` verifies an API key against the `APIToken` table and injects `tenant_id` into the handler.
+
+## 4. MySQL Handling Modules
+- Database connections are defined in `api/db/db_models.py` using `PooledMySQLDatabase`.
+- ORM models such as `User`, `Tenant`, `Knowledgebase` reside in this file and are used by service classes under `api/db/services/`.
+- The `conf/service_conf.yaml` file specifies MySQL connection parameters like host, port and credentials.
+
+## 5. MinIO Storage Modules
+- `rag/utils/minio_conn.py` implements `RAGFlowMinio`, a thin wrapper over the `minio` client to upload, download and manage objects.
+- `rag/utils/storage_factory.py` selects the storage implementation (MinIO by default).
+- Background tasks (`rag/svr/task_executor.py`) retrieve files from MinIO before processing.
+
+Only the Python backend components are documented here; the front‑end under `web/` is covered separately.

--- a/conf/service_conf.yaml
+++ b/conf/service_conf.yaml
@@ -14,6 +14,9 @@ minio:
   user: 'xxxx'
   password: 'xxxx'
   host: 'localhost:9001'
+datafile:
+  storage: 'minio'
+  local_path: './datafiles'
 es:
   hosts: 'https://localhost:9200'
   username: 'elastic'

--- a/rag/utils/local_storage.py
+++ b/rag/utils/local_storage.py
@@ -1,0 +1,45 @@
+import os
+import logging
+from rag.utils import singleton
+from rag import settings
+
+@singleton
+class LocalFileStorage:
+    def __init__(self):
+        self.base_path = settings.LOCAL_STORAGE_PATH
+        os.makedirs(self.base_path, exist_ok=True)
+
+    def _path(self, bucket, fnm):
+        bucket_dir = os.path.join(self.base_path, bucket)
+        os.makedirs(bucket_dir, exist_ok=True)
+        return os.path.join(bucket_dir, fnm)
+
+    def put(self, bucket, fnm, binary):
+        path = self._path(bucket, fnm)
+        with open(path, 'wb') as f:
+            f.write(binary)
+        return True
+
+    def rm(self, bucket, fnm):
+        try:
+            os.remove(self._path(bucket, fnm))
+        except FileNotFoundError:
+            logging.warning("File not found: %s/%s", bucket, fnm)
+
+    def get(self, bucket, fnm):
+        with open(self._path(bucket, fnm), 'rb') as f:
+            return f.read()
+
+    def obj_exist(self, bucket, fnm):
+        return os.path.exists(self._path(bucket, fnm))
+
+    def health(self):
+        try:
+            test_path = self._path("health", "check")
+            with open(test_path, "wb") as f:
+                f.write(b"ok")
+            os.remove(test_path)
+            return True
+        except Exception as e:
+            logging.exception("Local storage health check failed: %s", e)
+            return False

--- a/rag/utils/storage_factory.py
+++ b/rag/utils/storage_factory.py
@@ -21,6 +21,7 @@ from rag.utils.azure_sas_conn import RAGFlowAzureSasBlob
 from rag.utils.azure_spn_conn import RAGFlowAzureSpnBlob
 from rag.utils.minio_conn import RAGFlowMinio
 from rag.utils.opendal_conn import OpenDALStorage
+from rag.utils.local_storage import LocalFileStorage
 from rag.utils.s3_conn import RAGFlowS3
 from rag.utils.oss_conn import RAGFlowOSS
 
@@ -32,6 +33,7 @@ class Storage(Enum):
     AWS_S3 = 4
     OSS = 5
     OPENDAL = 6
+    LOCAL = 7
 
 
 class StorageFactory:
@@ -41,7 +43,8 @@ class StorageFactory:
         Storage.AZURE_SAS: RAGFlowAzureSasBlob,
         Storage.AWS_S3: RAGFlowS3,
         Storage.OSS: RAGFlowOSS,
-        Storage.OPENDAL: OpenDALStorage
+        Storage.OPENDAL: OpenDALStorage,
+        Storage.LOCAL: LocalFileStorage
     }
 
     @classmethod
@@ -49,5 +52,11 @@ class StorageFactory:
         return cls.storage_mapping[storage]()
 
 
-STORAGE_IMPL_TYPE = os.getenv('STORAGE_IMPL', 'MINIO')
+from rag import settings
+import logging
+
+STORAGE_IMPL_TYPE = settings.STORAGE_IMPL_TYPE.upper()
 STORAGE_IMPL = StorageFactory.create(Storage[STORAGE_IMPL_TYPE])
+logging.info("****** STORAGE IMPLEMENTATION: %s ******", STORAGE_IMPL_TYPE)
+if STORAGE_IMPL_TYPE == 'LOCAL':
+    logging.info("Local storage path: %s", settings.LOCAL_STORAGE_PATH)

--- a/web/src/layouts/index.tsx
+++ b/web/src/layouts/index.tsx
@@ -15,7 +15,7 @@ const App: React.FC = () => {
     token: { colorBgContainer, borderRadiusLG },
   } = theme.useToken();
 
-  const simpleMode = authorizationUtil.isQueryRole();
+  const simpleMode = authorizationUtil.isNormalRole();
   return (
     <Layout className={styles.layout}>
       <Layout>

--- a/web/src/layouts/next.tsx
+++ b/web/src/layouts/next.tsx
@@ -5,7 +5,7 @@ import authorizationUtil from '@/utils/authorization-util';
 
 
 export default function NextLayout() {
-  const simpleMode = authorizationUtil.isQueryRole();
+  const simpleMode = authorizationUtil.isNormalRole();
 
   return (
     <section className="h-full flex flex-col text-colors-text-neutral-strong">

--- a/web/src/pages/chat/index.tsx
+++ b/web/src/pages/chat/index.tsx
@@ -51,7 +51,7 @@ const { Text } = Typography;
 
 const Chat = () => {
   const { data: dialogList, loading: dialogLoading } = useFetchNextDialogList();
-  const simpleMode = authorizationUtil.isQueryRole();
+  const simpleMode = authorizationUtil.isNormalRole();
   const { onRemoveDialog } = useDeleteDialog();
   const { onRemoveConversation } = useDeleteConversation();
   const { handleClickDialog } = useClickDialogCard();

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -38,7 +38,7 @@ const Login = () => {
   useEffect(() => {
     if (isLogin) {
       const role = authorizationUtil.getUserRole();
-      navigate(role === 'query' ? '/chat' : '/knowledge');
+      navigate(role === 'normal' ? '/chat' : '/knowledge');
     }
   }, [isLogin, navigate]);
 
@@ -71,7 +71,7 @@ const Login = () => {
         });
         if (code === 0) {
           const role = authorizationUtil.getUserRole();
-          navigate(role === 'query' ? '/chat' : '/knowledge');
+          navigate(role === 'normal' ? '/chat' : '/knowledge');
         }
       } else {
         const code = await register({

--- a/web/src/pages/user-setting/sidebar/index.tsx
+++ b/web/src/pages/user-setting/sidebar/index.tsx
@@ -23,7 +23,7 @@ const SideBar = () => {
   const { logout } = useLogout();
   const { t } = useTranslate('setting');
   const { version, fetchSystemVersion } = useFetchSystemVersion();
-  const simple = authorizationUtil.isQueryRole();
+  const simple = authorizationUtil.isNormalRole();
 
   useEffect(() => {
     if (location.host !== Domain) {

--- a/web/src/utils/authorization-util.ts
+++ b/web/src/utils/authorization-util.ts
@@ -26,8 +26,8 @@ const storage = {
       return undefined;
     }
   },
-  isQueryRole: () => {
-    return storage.getUserRole() === 'query';
+  isNormalRole: () => {
+    return storage.getUserRole() === 'normal';
   },
   setAuthorization: (value: string) => {
     localStorage.setItem(Authorization, value);


### PR DESCRIPTION
## Summary
- normalize storage implementation from config to upper case
- log storage type and local path on startup for visibility

## Testing
- `python -m py_compile api/apps/user_app.py api/db/db_models.py api/db/init_data.py rag/settings.py rag/utils/storage_factory.py rag/utils/local_storage.py`
- `npm run lint` *(fails: umi not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcf0b98448332af2796436e7593b1